### PR TITLE
Dismiss progress Dialog instead of hiding it

### DIFF
--- a/opensrp-enketo/src/main/java/org/smartregister/enketo/view/fragment/DisplayFormFragment.java
+++ b/opensrp-enketo/src/main/java/org/smartregister/enketo/view/fragment/DisplayFormFragment.java
@@ -237,7 +237,7 @@ public class DisplayFormFragment extends Fragment {
             @Override
             public void run() {
                 if (progressDialog.isShowing()) {
-                    progressDialog.hide();
+                    progressDialog.dismiss();
                 }
             }
         });


### PR DESCRIPTION
Dismiss progress Dialog instead of hiding it. Hiding causes android.view.WindowLeaked error when the activity hosting DisplayFormFragment is stopped

